### PR TITLE
convert numpy array to torch tensor in the right place

### DIFF
--- a/crepe/__init__.py
+++ b/crepe/__init__.py
@@ -1,2 +1,2 @@
 from .version import version as __version__
-from .core import get_activation, predict, process_file
+from .core import get_activation, predict, process_file, clear_model_cache

--- a/crepe/__init__.py
+++ b/crepe/__init__.py
@@ -1,2 +1,2 @@
 from .version import version as __version__
-from .core import get_activation, predict, process_file, clear_model_cache
+from .core import get_activation, predict, process_file

--- a/crepe/core.py
+++ b/crepe/core.py
@@ -9,8 +9,6 @@ from scipy.io import wavfile
 import numpy as np
 from numpy.lib.stride_tricks import as_strided
 
-from ipdb import set_trace
-
 backends = ["tf", "torch"]
 
 # store as a global variable, since we only support a few models for now

--- a/crepe/core.py
+++ b/crepe/core.py
@@ -282,6 +282,13 @@ def get_activation(audio, sr, model_capacity='full', center=True, step_size=10,
                 "Resampling not supported in Torch backend")
 
         import torch
+
+        audio = torch.from_numpy(audio)
+        if len(audio.shape) < 2:
+            audio = audio.view((1, -1))
+        device = next(iter(model.parameters())).device
+        audio = audio.to(device)
+
         model.eval()
         with torch.no_grad():
             logits = model.forward_audio(audio)
@@ -403,14 +410,6 @@ def process_file(file, output=None, model_capacity='full', viterbi=False,
     except ValueError:
         print("CREPE: Could not read %s" % file, file=sys.stderr)
         raise
-
-    if backend == 'torch':
-        import torch
-        # batch input
-        audio = torch.as_tensor(audio).unsqueeze(0)
-        # send to GPU if available
-        device = 'cuda:0' if torch.cuda.is_available() else 'cpu'
-        audio = audio.to(device)
 
     time, frequency, confidence, activation = predict(
         audio, sr,

--- a/crepe/core.py
+++ b/crepe/core.py
@@ -9,20 +9,25 @@ from scipy.io import wavfile
 import numpy as np
 from numpy.lib.stride_tricks import as_strided
 
-backends = ['tf', 'torch']
+from ipdb import set_trace
+
+backends = ["tf", "torch"]
 
 # store as a global variable, since we only support a few models for now
-models = {backend: {
-    'tiny': None,
-    'small': None,
-    'medium': None,
-    'large': None,
-    'full': None}
-          for backend in backends
+models = {
+    backend: {"tiny": None, "small": None, "medium": None, "large": None, "full": None}
+    for backend in backends
 }
 
 # the model is trained on 16kHz audio
 model_srate = 16000
+
+
+def clear_model_cache():
+    global models
+    for _, bmodels in models.items():
+        for size in bmodels.keys():
+            bmodels[size] = None
 
 
 def build_and_load_model_tf(model_capacity: str):
@@ -44,15 +49,17 @@ def build_and_load_model_tf(model_capacity: str):
     model : tensorflow.keras.models.Model
         The pre-trained model loaded in memory
     """
-    from tensorflow.keras.layers import (Input, Reshape, Conv2D,
-                                         BatchNormalization)
-    from tensorflow.keras.layers import (MaxPool2D, Dropout, Permute, Flatten,
-                                         Dense)
+    from tensorflow.keras.layers import Input, Reshape, Conv2D, BatchNormalization
+    from tensorflow.keras.layers import MaxPool2D, Dropout, Permute, Flatten, Dense
     from tensorflow.keras.models import Model
 
-    if models['tf'][model_capacity] is None:
+    if models["tf"][model_capacity] is None:
         capacity_multiplier = {
-            'tiny': 4, 'small': 8, 'medium': 16, 'large': 24, 'full': 32
+            "tiny": 4,
+            "small": 8,
+            "medium": 16,
+            "large": 24,
+            "full": 32,
         }[model_capacity]
 
         layers = [1, 2, 3, 4, 5, 6]
@@ -60,32 +67,42 @@ def build_and_load_model_tf(model_capacity: str):
         widths = [512, 64, 64, 64, 64, 64]
         strides = [(4, 1), (1, 1), (1, 1), (1, 1), (1, 1), (1, 1)]
 
-        x = Input(shape=(1024,), name='input', dtype='float32')
-        y = Reshape(target_shape=(1024, 1, 1), name='input-reshape')(x)
+        x = Input(shape=(1024,), name="input", dtype="float32")
+        y = Reshape(target_shape=(1024, 1, 1), name="input-reshape")(x)
 
         for l, f, w, s in zip(layers, filters, widths, strides):
-            y = Conv2D(f, (w, 1), strides=s, padding='same',
-                       activation='relu', name="conv%d" % l)(y)
+            y = Conv2D(
+                f,
+                (w, 1),
+                strides=s,
+                padding="same",
+                activation="relu",
+                name="conv%d" % l,
+            )(y)
             y = BatchNormalization(name="conv%d-BN" % l)(y)
-            y = MaxPool2D(pool_size=(2, 1), strides=None, padding='valid',
-                          name="conv%d-maxpool" % l)(y)
+            y = MaxPool2D(
+                pool_size=(2, 1),
+                strides=None,
+                padding="valid",
+                name="conv%d-maxpool" % l,
+            )(y)
             y = Dropout(0.25, name="conv%d-dropout" % l)(y)
 
         y = Permute((2, 1, 3), name="transpose")(y)
         y = Flatten(name="flatten")(y)
-        y = Dense(360, activation='sigmoid', name="classifier")(y)
+        y = Dense(360, activation="sigmoid", name="classifier")(y)
 
         model = Model(inputs=x, outputs=y)
 
         package_dir = os.path.dirname(os.path.realpath(__file__))
         filename = "model-{}.h5".format(model_capacity)
         model.load_weights(os.path.join(package_dir, filename))
-        model.compile('adam', 'binary_crossentropy')
+        model.compile("adam", "binary_crossentropy")
 
-        models['tf'][model_capacity] = model
+        models["tf"][model_capacity] = model
 
 
-def build_and_load_model(model_capacity: str, backend: str = 'tf'):
+def build_and_load_model(model_capacity: str, backend: str = "tf"):
     """
     Build the CNN model and load the weights
 
@@ -105,17 +122,19 @@ def build_and_load_model(model_capacity: str, backend: str = 'tf'):
         The pre-trained model loaded in memory using the chosen backend
     """
     if models[backend][model_capacity] is None:
-        if backend == 'tf':
+        if backend == "tf":
             build_and_load_model_tf(model_capacity)
-        elif backend == 'torch':
-            from .torch_backend import build_and_load_model \
-                as build_and_load_model_torch
+        elif backend == "torch":
+            from .torch_backend import (
+                build_and_load_model as build_and_load_model_torch,
+            )
+
             model = build_and_load_model_torch(model_capacity)
-            models['torch'][model_capacity] = model
+            models["torch"][model_capacity] = model
         else:
             raise ValueError(
-                f"Unexpected backend {backend}, possible choices are: "
-                f"{backends}")
+                f"Unexpected backend {backend}, possible choices are: " f"{backends}"
+            )
     return models[backend][model_capacity]
 
 
@@ -133,10 +152,11 @@ def to_local_average_cents(salience, center=None):
     """
     find the weighted average cents near the argmax bin
     """
-    if not hasattr(to_local_average_cents, 'cents_mapping'):
+    if not hasattr(to_local_average_cents, "cents_mapping"):
         # the bin number-to-cents mapping
         to_local_average_cents.cents_mapping = (
-            np.linspace(0, 7180, 360) + 1997.3794084376191)
+            np.linspace(0, 7180, 360) + 1997.3794084376191
+        )
 
     if salience.ndim == 1:
         if center is None:
@@ -144,13 +164,13 @@ def to_local_average_cents(salience, center=None):
         start = max(0, center - 4)
         end = min(len(salience), center + 5)
         salience = salience[start:end]
-        product_sum = np.sum(
-            salience * to_local_average_cents.cents_mapping[start:end])
+        product_sum = np.sum(salience * to_local_average_cents.cents_mapping[start:end])
         weight_sum = np.sum(salience)
         return product_sum / weight_sum
     if salience.ndim == 2:
-        return np.array([to_local_average_cents(salience[i, :]) for i in
-                        range(salience.shape[0])])
+        return np.array(
+            [to_local_average_cents(salience[i, :]) for i in range(salience.shape[0])]
+        )
 
     raise Exception("label should be either 1d or 2d ndarray")
 
@@ -173,20 +193,28 @@ def to_viterbi_cents(salience):
     # emission probability = fixed probability for self, evenly distribute the
     # others
     self_emission = 0.1
-    emission = (np.eye(360) * self_emission + np.ones(shape=(360, 360)) *
-                ((1 - self_emission) / 360))
+    emission = np.eye(360) * self_emission + np.ones(shape=(360, 360)) * (
+        (1 - self_emission) / 360
+    )
 
     # fix the model parameters because we are not optimizing the model
     model = hmm.MultinomialHMM(360, starting, transition)
-    model.startprob_, model.transmat_, model.emissionprob_ = \
-        starting, transition, emission
+    model.startprob_, model.transmat_, model.emissionprob_ = (
+        starting,
+        transition,
+        emission,
+    )
 
     # find the Viterbi path
     observations = np.argmax(salience, axis=1)
     path = model.predict(observations.reshape(-1, 1), [len(observations)])
 
-    return np.array([to_local_average_cents(salience[i, :], path[i]) for i in
-                     range(len(observations))])
+    return np.array(
+        [
+            to_local_average_cents(salience[i, :], path[i])
+            for i in range(len(observations))
+        ]
+    )
 
 
 def get_frames(audio, sr, center=True, step_size=10, normalize: bool = True):
@@ -216,20 +244,23 @@ def get_frames(audio, sr, center=True, step_size=10, normalize: bool = True):
     if sr != model_srate:
         # resample audio if necessary
         from resampy import resample
+
         audio = resample(audio, sr, model_srate)
 
     # pad so that frames are centered around their timestamps (i.e. first frame
     # is zero centered).
     if center:
-        audio = np.pad(audio, 512, mode='constant', constant_values=0)
+        audio = np.pad(audio, 512, mode="constant", constant_values=0)
 
     # make 1024-sample frames of the audio with hop length of 10 milliseconds
     hop_length = int(model_srate * step_size / 1000)
     n_frames = 1 + int((len(audio) - 1024) / hop_length)
-    frames = as_strided(audio, shape=(1024, n_frames),
-                        strides=(audio.itemsize, hop_length * audio.itemsize),
-                        writeable=False
-                        ).copy()
+    frames = as_strided(
+        audio,
+        shape=(1024, n_frames),
+        strides=(audio.itemsize, hop_length * audio.itemsize),
+        writeable=False,
+    ).copy()
     frames = frames.transpose()
 
     if normalize:
@@ -239,8 +270,15 @@ def get_frames(audio, sr, center=True, step_size=10, normalize: bool = True):
     return frames
 
 
-def get_activation(audio, sr, model_capacity='full', center=True, step_size=10,
-                   verbose=1, backend: str = 'tf'):
+def get_activation(
+    audio,
+    sr,
+    model_capacity="full",
+    center=True,
+    step_size=10,
+    verbose=1,
+    backend: str = "tf",
+):
     """
 
     Parameters
@@ -270,45 +308,22 @@ def get_activation(audio, sr, model_capacity='full', center=True, step_size=10,
     """
     model = build_and_load_model(model_capacity, backend=backend)
 
-    if backend == 'tf':
-        frames = get_frames(audio, sr, center=center, step_size=step_size)
-        # run prediction and convert the frequency bin weights to Hz
-        activation = model.predict(frames, verbose=verbose)
-    elif backend == 'torch':
-        assert center == model.center
-        assert step_size == 1000 * model.hop_length_s
-        if sr != model.fs_hz:
-            raise NotImplementedError(
-                "Resampling not supported in Torch backend")
-
-        import torch
-
-        audio = torch.from_numpy(audio)
-        if len(audio.shape) == 1:
-            # add batch dimension
-            audio = audio.unsqueeze(0)
-            # add batch dimension
-            audio = audio.unsqueeze(-1)
-        elif len(audio.shape) == 2:
-            # add batch dimension
-            audio = audio.unsqueeze(0)
-        else:
-            raise Exception("Only 1D and 2D signals are supported")
-
-        device = next(iter(model.parameters())).device
-        audio = audio.to(device)
-
-        model.eval()
-        with torch.no_grad():
-            logits = model.forward_audio(audio)
-            activation = torch.sigmoid(logits)
-
+    frames = get_frames(audio, sr, center=center, step_size=step_size)
+    # run prediction and convert the frequency bin weights to Hz
+    activation = model.predict(frames, verbose=verbose)
     return activation
 
 
-def predict(audio, sr, model_capacity='full',
-            viterbi=False, center=True, step_size=10, verbose=1,
-            backend: str = 'tf'):
+def predict(
+    audio,
+    sr,
+    model_capacity="full",
+    viterbi=False,
+    center=True,
+    step_size=10,
+    verbose=1,
+    backend: str = "tf",
+):
     """
     Perform pitch estimation on given audio
 
@@ -347,10 +362,16 @@ def predict(audio, sr, model_capacity='full',
         activation: np.ndarray [shape=(T, 360)]
             The raw activation matrix
     """
-    activation = get_activation(audio, sr, model_capacity=model_capacity,
-                                center=center, step_size=step_size,
-                                verbose=verbose, backend=backend)
-    if backend == 'tf':
+    activation = get_activation(
+        audio,
+        sr,
+        model_capacity=model_capacity,
+        center=center,
+        step_size=step_size,
+        verbose=verbose,
+        backend=backend,
+    )
+    if True:  # backend == "tf":
         confidence = activation.max(axis=1)
 
         if viterbi:
@@ -362,21 +383,23 @@ def predict(audio, sr, model_capacity='full',
         frequency[np.isnan(frequency)] = 0
 
         time = np.arange(confidence.shape[0]) * step_size / 1000.0
-    elif backend == 'torch':
-        if viterbi:
-            raise NotImplementedError(
-                "Viterbi decoding not yet implemented in PyTorch")
-        model = build_and_load_model(model_capacity, 'torch')
-        time, frequency, confidence = model.data_helper.interpret_activation(
-            activation)
 
     return time, frequency, confidence, activation
 
 
-def process_file(file, output=None, model_capacity='full', viterbi=False,
-                 center=True, save_activation=False, save_plot=False,
-                 plot_voicing=False, step_size=10, verbose=True,
-                 backend: str = 'tf'):
+def process_file(
+    file,
+    output=None,
+    model_capacity="full",
+    viterbi=False,
+    center=True,
+    save_activation=False,
+    save_plot=False,
+    plot_voicing=False,
+    step_size=10,
+    verbose=True,
+    backend: str = "tf",
+):
     """
     Use the input model to perform pitch estimation on the input file.
 
@@ -421,38 +444,47 @@ def process_file(file, output=None, model_capacity='full', viterbi=False,
         raise
 
     time, frequency, confidence, activation = predict(
-        audio, sr,
+        audio,
+        sr,
         model_capacity=model_capacity,
         center=center,
         viterbi=viterbi,
         step_size=step_size,
         verbose=1 * verbose,
-        backend=backend)
+        backend=backend,
+    )
 
-    if backend == 'torch':
-        time, frequency, confidence, activation = (
-            time[0].cpu().numpy(),
-            frequency[0].cpu().numpy(),
-            confidence[0].cpu().numpy(),
-            activation[0].cpu().numpy()
-        )
+    # if backend == "torch":
+    #     time, frequency, confidence, activation = (
+    #         time[0].cpu().numpy(),
+    #         frequency[0].cpu().numpy(),
+    #         confidence[0].cpu().numpy(),
+    #         activation[0].cpu().numpy(),
+    #     )
 
     # write prediction as TSV
     f0_file = output_path(file, ".f0.csv", output)
     f0_data = np.vstack([time, frequency, confidence]).transpose()
-    np.savetxt(f0_file, f0_data, fmt=['%.3f', '%.3f', '%.6f'], delimiter=',',
-               header='time,frequency,confidence', comments='')
+    np.savetxt(
+        f0_file,
+        f0_data,
+        fmt=["%.3f", "%.3f", "%.6f"],
+        delimiter=",",
+        header="time,frequency,confidence",
+        comments="",
+    )
     if verbose:
-        print("CREPE: Saved the estimated frequencies and confidence values "
-              "at {}".format(f0_file))
+        print(
+            "CREPE: Saved the estimated frequencies and confidence values "
+            "at {}".format(f0_file)
+        )
 
     # save the salience file to a .npy file
     if save_activation:
         activation_path = output_path(file, ".activation.npy", output)
         np.save(activation_path, activation)
         if verbose:
-            print("CREPE: Saved the activation matrix at {}".format(
-                activation_path))
+            print("CREPE: Saved the activation matrix at {}".format(activation_path))
 
     # save the salience visualization in a PNG file
     if save_plot:
@@ -462,16 +494,17 @@ def process_file(file, output=None, model_capacity='full', viterbi=False,
         plot_file = output_path(file, ".activation.png", output)
         # to draw the low pitches in the bottom
         salience = np.flip(activation, axis=1)
-        inferno = matplotlib.cm.get_cmap('inferno')
+        inferno = matplotlib.cm.get_cmap("inferno")
         image = inferno(salience.transpose())
 
         if plot_voicing:
             # attach a soft and hard voicing detection result under the
             # salience plot
-            image = np.pad(image, [(0, 20), (0, 0), (0, 0)], mode='constant')
+            image = np.pad(image, [(0, 20), (0, 0), (0, 0)], mode="constant")
             image[-20:-10, :, :] = inferno(confidence)[np.newaxis, :, :]
-            image[-10:, :, :] = (
-                inferno((confidence > 0.5).astype(np.float))[np.newaxis, :, :])
+            image[-10:, :, :] = inferno((confidence > 0.5).astype(np.float))[
+                np.newaxis, :, :
+            ]
 
         imwrite(plot_file, (255 * image).astype(np.uint8))
         if verbose:

--- a/crepe/core.py
+++ b/crepe/core.py
@@ -284,8 +284,17 @@ def get_activation(audio, sr, model_capacity='full', center=True, step_size=10,
         import torch
 
         audio = torch.from_numpy(audio)
-        if len(audio.shape) < 2:
-            audio = audio.view((1, -1))
+        if len(audio.shape) == 1:
+            # add batch dimension
+            audio = audio.unsqueeze(0)
+            # add batch dimension
+            audio = audio.unsqueeze(-1)
+        elif len(audio.shape) == 2:
+            # add batch dimension
+            audio = audio.unsqueeze(0)
+        else:
+            raise Exception("Only 1D and 2D signals are supported")
+
         device = next(iter(model.parameters())).device
         audio = audio.to(device)
 

--- a/crepe/torch_backend.py
+++ b/crepe/torch_backend.py
@@ -7,21 +7,26 @@ import numpy as np
 
 import torch
 from torch import nn
+from torch.utils.data import DataLoader
 import torch.nn.functional as F
 import h5py
+from crepe.core import get_frames
+
+from ipdb import set_trace
 
 # store as a global variable, since we only support a few models for now
-models: Dict[str, Optional['CREPE']] = {
-    'tiny': None,
-    'small': None,
-    'medium': None,
-    'large': None,
-    'full': None
+models: Dict[str, Optional["CREPE"]] = {
+    "tiny": None,
+    "small": None,
+    "medium": None,
+    "large": None,
+    "full": None,
 }
 
 
-def _get_keras_weights(weights: h5py.File, group_name: str,
-                       parameter_name: str) -> torch.Tensor:
+def _get_keras_weights(
+    weights: h5py.File, group_name: str, parameter_name: str
+) -> torch.Tensor:
     """Retrieve weights for a given layer's parameter
     Example usage:
     >>> weights = h5py.File(PATH_TO_MODEL, 'r')
@@ -31,7 +36,7 @@ def _get_keras_weights(weights: h5py.File, group_name: str,
     parent_group = weights[group_name]
     access_key = next(iter(parent_group.keys()))
     group = parent_group[access_key]
-    return torch.as_tensor(group[parameter_name + ':0'][()])
+    return torch.as_tensor(group[parameter_name + ":0"][()])
 
 
 # custom conv1d since PyTorch does not support 'SAME' padding as in TensorFlow
@@ -41,7 +46,7 @@ def _get_keras_weights(weights: h5py.File, group_name: str,
 class Conv1d_samePadding(nn.Conv1d):
     def __init__(self, *args, padding: int = 0, **kwargs):
         assert padding == 0, "no additional padding on top of 'same' padding"
-        kwargs['padding'] = 0
+        kwargs["padding"] = 0
         super().__init__(*args, **kwargs)
 
     def same_padding_1d(self, input):
@@ -50,12 +55,18 @@ class Conv1d_samePadding(nn.Conv1d):
         out_duration = (input_duration + self.stride[0] - 1) // self.stride[0]
         padding_duration = max(
             0,
-            ((out_duration - 1) * self.stride[0]
-             + (filter_duration - 1) * self.dilation[0] + 1 - input_duration))
+            (
+                (out_duration - 1) * self.stride[0]
+                + (filter_duration - 1) * self.dilation[0]
+                + 1
+                - input_duration
+            ),
+        )
         duration_odd = padding_duration % 2
 
-        input = F.pad(input, (padding_duration // 2,
-                              padding_duration // 2 + int(duration_odd)))
+        input = F.pad(
+            input, (padding_duration // 2, padding_duration // 2 + int(duration_odd))
+        )
 
         return input
 
@@ -66,14 +77,19 @@ class Conv1d_samePadding(nn.Conv1d):
 
 class CrepeLayer(nn.Module):
     """Define a single convolutional layer for the CREPE model"""
-    def __init__(self, in_channels: int, filters: int,
-                 width: int, stride: int, layer_index: int):
+
+    def __init__(
+        self, in_channels: int, filters: int, width: int, stride: int, layer_index: int
+    ):
         super().__init__()
         self.layer_index = layer_index
 
         self.conv = Conv1d_samePadding(
-            in_channels=in_channels, out_channels=filters, stride=stride,
-            kernel_size=width)
+            in_channels=in_channels,
+            out_channels=filters,
+            stride=stride,
+            kernel_size=width,
+        )
         self.batch_norm = nn.BatchNorm1d(filters)
         self.maxpool = nn.MaxPool1d(kernel_size=2, stride=None, padding=0)
         self.dropout = nn.Dropout(0.25)
@@ -88,37 +104,40 @@ class CrepeLayer(nn.Module):
 
     def load_keras_weights(self, weights: h5py.File):
         """Load weights from a keras pretrained layer"""
-        h5_layer_name = f'conv{self.layer_index}'
+        h5_layer_name = f"conv{self.layer_index}"
 
         # load the weights for the convolutional layer
         conv_layer_name = h5_layer_name
         conv_kernel_matrix = (
-            _get_keras_weights(weights, conv_layer_name, 'kernel')
+            _get_keras_weights(weights, conv_layer_name, "kernel")
             # squeezing since the TF implementation uses 2D convolutions
             # although the kernels are actually 1D
             .squeeze(1)
             # transpose to adapt to Keras' weights shape
-            .transpose(0, 2))
+            .transpose(0, 2)
+        )
         assert self.conv.weight.data.shape == conv_kernel_matrix.shape
         self.conv.weight.data = conv_kernel_matrix
 
-        self.conv.bias.data = _get_keras_weights(
-            weights, conv_layer_name, 'bias')
+        self.conv.bias.data = _get_keras_weights(weights, conv_layer_name, "bias")
 
         # load the weights for the BatchNorm layer
-        bn_layer_name = h5_layer_name + '-BN'
+        bn_layer_name = h5_layer_name + "-BN"
         self.batch_norm.weight.data = _get_keras_weights(
-            weights, bn_layer_name, 'gamma')
-        self.batch_norm.bias.data = _get_keras_weights(
-            weights, bn_layer_name, 'beta')
+            weights, bn_layer_name, "gamma"
+        )
+        self.batch_norm.bias.data = _get_keras_weights(weights, bn_layer_name, "beta")
         self.batch_norm.running_mean.data = _get_keras_weights(
-            weights, bn_layer_name, 'moving_mean')
+            weights, bn_layer_name, "moving_mean"
+        )
         self.batch_norm.running_var.data = _get_keras_weights(
-            weights, bn_layer_name, 'moving_variance')
+            weights, bn_layer_name, "moving_variance"
+        )
 
 
 class CREPE(nn.Module):
     """Define a 6-layer CREPE pitch-prediction model"""
+
     # the model is trained on 16kHz audio
     fs_hz: int = 16000
 
@@ -135,17 +154,25 @@ class CREPE(nn.Module):
     num_filters_base = [32, 4, 4, 4, 8, 16]
 
     capacity_multipliers_per_capacity = {
-            'tiny': 4, 'small': 8, 'medium': 16, 'large': 24, 'full': 32
-        }
+        "tiny": 4,
+        "small": 8,
+        "medium": 16,
+        "large": 24,
+        "full": 32,
+    }
 
     # pad so that frames are centered around their timestamps (i.e. first frame
     # is zero centered).
     center = True
     normalize_frames = True
 
-    def __init__(self, model_capacity: str, frame_duration_n: int = 1024,
-                 hop_length_s: float = 10e-3,
-                 capacity_multiplier: Optional[int] = None):
+    def __init__(
+        self,
+        model_capacity: str,
+        frame_duration_n: int = 1024,
+        hop_length_s: float = 10e-3,
+        capacity_multiplier: Optional[int] = None,
+    ):
         super().__init__()
         self.frame_duration_n = frame_duration_n
         self.hop_length_s = hop_length_s
@@ -154,22 +181,20 @@ class CREPE(nn.Module):
         if capacity_multiplier is None:
             self.model_capacity = model_capacity
             self.capacity_multiplier = self.capacity_multipliers_per_capacity[
-                self.model_capacity]
+                self.model_capacity
+            ]
         else:
-            self.model_capacity = 'custom'
+            self.model_capacity = "custom"
             self.capacity_multiplier = capacity_multiplier
-        self.num_filters = [f * self.capacity_multiplier
-                            for f in self.num_filters_base]
+        self.num_filters = [f * self.capacity_multiplier for f in self.num_filters_base]
 
         layers: List[CrepeLayer] = []
 
         # initial number of channels
         out_channels_prev_layer = self.in_channels
-        for i, (f, w, s) in enumerate(
-                zip(self.num_filters, self.widths, self.strides)):
-            layer_index = i+1  # for consistency with the TF implementation
-            layers.append(CrepeLayer(out_channels_prev_layer, f, w, s,
-                                     layer_index))
+        for i, (f, w, s) in enumerate(zip(self.num_filters, self.widths, self.strides)):
+            layer_index = i + 1  # for consistency with the TF implementation
+            layers.append(CrepeLayer(out_channels_prev_layer, f, w, s, layer_index))
 
             out_channels_prev_layer = f
 
@@ -186,10 +211,12 @@ class CREPE(nn.Module):
 
         self.classifier = nn.Linear(classifier_input_len, self.num_classes)
 
-        self.data_helper = DataHelper(self.frame_duration_n,
-                                      self.hop_length_s,
-                                      self.center,
-                                      normalize=self.normalize_frames)
+        # self.data_helper = DataHelper(
+        #     self.frame_duration_n,
+        #     self.hop_length_s,
+        #     self.center,
+        #     normalize=self.normalize_frames,
+        # )
 
     def forward(self, input):
         if input.ndim == 2:
@@ -198,16 +225,36 @@ class CREPE(nn.Module):
 
         # apply successive 1D convolutional layers
         input = self.layers(input)
-
         # convert to logits
         input = input.transpose(1, 2)
+
         input = input.flatten(start_dim=1)
         logits = self.classifier(input)
         return logits
 
+    @torch.no_grad()
+    def predict(self, frames: np.ndarray, **kwargs) -> np.ndarray:
+        if len(frames.shape) == 2:
+            frames = np.expand_dims(frames, 1)
+
+        dev = next(iter(self.parameters()))
+
+        batch_size = 32
+        pin_mem = dev.name != "cpu"
+        data_loader = DataLoader(
+            frames, batch_size=batch_size, shuffle=False, pin_memory=pin_mem
+        )
+        output = []
+        for batch in data_loader:
+            output.append(self.forward(batch.to(dev)))
+        logits = torch.cat(output)
+        activation = torch.sigmoid(logits)
+        return activation.cpu().numpy()
+
     def load_keras_weights(self, weights_path: str):
         from h5py import File
-        with File(weights_path, 'r') as f:
+
+        with File(weights_path, "r") as f:
             # load the weights for all CREPE layers
             # ignore error on next line since
             # nn.Sequential.__iter__ is not detected by mypy
@@ -216,232 +263,219 @@ class CREPE(nn.Module):
 
             # load the weights for the final classifier layer
             self.classifier.weight.data = _get_keras_weights(
-                f, 'classifier', 'kernel').t()
-            self.classifier.bias.data = _get_keras_weights(
-                f, 'classifier', 'bias')
-
-    @torch.no_grad()
-    def predict(self, frames: np.ndarray, **kwargs
-                ) -> np.ndarray:
-        """Return predicted activation for the provided frames.
-
-        Provided for duck-typing with the TensorFlow backend.
-
-        Arguments:
-            frames (np.ndarray):
-                an array of frames with shape
-                (N_frames, self.frame_duration_n)
-                or (N_frames, 1, self.frame_duration_n)
-        Return:
-            np.ndarray of shape (N_frames, 360):
-                logits for each frame over the whole cents distribution
-        """
-        self.eval()
-
-        device = torch.device('cuda:0' if torch.cuda.is_available()
-                              else 'cpu')
-        self.to(device)
-        frames = torch.as_tensor(frames).to(device)
-
-        parallel_model = torch.nn.DataParallel(self)
-        logits = parallel_model(frames).cpu().numpy()
-        activation = torch.sigmoid(logits)
-        return activation
-
-    def forward_audio(self, audio: torch.Tensor) -> torch.Tensor:
-        """Helper function for computation on batched audio samples
-
-        Input arguments:
-            audio, torch.Tensor, shape [Batch, Time, Channels]
-            sr, int:
-                the sample rate of the audios, in Hz
-            center, bool, optional (default True):
-                whether to use frames centered on their timestamps
-                for analysis (if True, pads the input audio accordingly)
-            step_size, int, optional (default 10):
-                step size for extracting the frames
-        """
-        batch_size = audio.shape[0]
-        frames = self.data_helper.get_frames(audio)
-        frames = frames.flatten(0, 1)
-        logits = self.forward(frames)
-        # reshape as (Batch, Num_frames_in_sample, Num_classes)
-        return logits.unsqueeze(0).view(batch_size, -1,
-                                        self.num_classes)
+                f, "classifier", "kernel"
+            ).t()
+            self.classifier.bias.data = _get_keras_weights(f, "classifier", "bias")
 
 
-class DataHelper(nn.Module):
-    fs_hz: int = 16000
-    num_bins_cents: int = 360
-    a4_frequency_hz: float = 440
-    cents_reference_frequency_hz: float = 10
-    cents_gaussian_bluring_std_cents: float = 25
-    # as used in the original CREPE repository
-    local_averaging_window_relative_length: int = 4
+# class DataHelper(nn.Module):
+#     fs_hz: int = 16000
+#     num_bins_cents: int = 360
+#     a4_frequency_hz: float = 440
+#     cents_reference_frequency_hz: float = 10
+#     cents_gaussian_bluring_std_cents: float = 25
+#     # as used in the original CREPE repository
+#     local_averaging_window_relative_length: int = 4
 
-    def __init__(self, frame_duration_n: int, hop_length_s: float,
-                 center: bool, normalize: bool):
-        super().__init__()
-        self.frame_duration_n = frame_duration_n
-        self.hop_length_s = hop_length_s
-        self.hop_length_n = int(self.hop_length_s * self.fs_hz)
-        self.center = center
-        self.normalize = normalize
+#     def __init__(
+#         self, frame_duration_n: int, hop_length_s: float, center: bool, normalize: bool
+#     ):
+#         super().__init__()
+#         self.frame_duration_n = frame_duration_n
+#         self.hop_length_s = hop_length_s
+#         self.hop_length_n = int(self.hop_length_s * self.fs_hz)
+#         self.center = center
+#         self.normalize = normalize
 
-        self._padding_width = 4
-        self._pad = nn.ConstantPad1d(self._padding_width, 0)
-        self._to_local_average_cents_matrix = nn.Parameter(
-            torch.linspace(0, 7180, self.num_bins_cents) + 1997.3794084376191,
-            requires_grad=False)
+#         self._padding_width = 4
+#         self._pad = nn.ConstantPad1d(self._padding_width, 0)
+#         self._to_local_average_cents_matrix = nn.Parameter(
+#             torch.linspace(0, 7180, self.num_bins_cents) + 1997.3794084376191,
+#             requires_grad=False,
+#         )
 
-    def to_local_average_cents(self, salience: torch.Tensor, center=None):
-        # will not mess up the subsequent argmax since the salience is > 0
-        salience = self._pad(salience)
+#     def to_local_average_cents(self, salience: torch.Tensor, center=None):
+#         # will not mess up the subsequent argmax since the salience is > 0
+#         salience = self._pad(salience)
 
-        if center is None:
-            center = torch.argmax(salience, dim=-1, keepdim=True)
+#         if center is None:
+#             center = torch.argmax(salience, dim=-1, keepdim=True)
 
-        relative_window_indexes = (
-            torch.arange(
-                -self.local_averaging_window_relative_length,
-                self.local_averaging_window_relative_length + 1)
-            .unsqueeze(0)
-            .to(center.device)
-            )
-        window_indexes = (center + relative_window_indexes)
-        # extract window of salience values over most salient pitch
-        salience = salience.gather(-1, window_indexes)
+#         relative_window_indexes = (
+#             torch.arange(
+#                 -self.local_averaging_window_relative_length,
+#                 self.local_averaging_window_relative_length + 1,
+#             )
+#             .unsqueeze(0)
+#             .to(center.device)
+#         )
+#         window_indexes = center + relative_window_indexes
+#         # extract window of salience values over most salient pitch
+#         salience = salience.gather(-1, window_indexes)
 
-        product_sum = torch.sum(
-            salience
-            * (self._pad(self._to_local_average_cents_matrix)
-               .expand(*window_indexes.shape[:-1], -1)
-               .gather(-1, window_indexes)),
-            dim=-1)
-        weight_sum = salience.sum(-1)
+#         product_sum = torch.sum(
+#             salience
+#             * (
+#                 self._pad(self._to_local_average_cents_matrix)
+#                 .expand(*window_indexes.shape[:-1], -1)
+#                 .gather(-1, window_indexes)
+#             ),
+#             dim=-1,
+#         )
+#         weight_sum = salience.sum(-1)
 
-        average_cents = product_sum / weight_sum
-        return average_cents
+#         average_cents = product_sum / weight_sum
+#         return average_cents
 
-    def cents_to_hz(self, cents: torch.Tensor) -> torch.Tensor:
-        """Convert frequencies in cents to hertz"""
-        hertz = self.cents_reference_frequency_hz * (
-            2 ** (cents / 1200))  # type: ignore
-        hertz[torch.isnan(hertz)] = 0
-        return hertz
+#     def cents_to_hz(self, cents: torch.Tensor) -> torch.Tensor:
+#         """Convert frequencies in cents to hertz"""
+#         hertz = self.cents_reference_frequency_hz * (
+#             2 ** (cents / 1200)
+#         )  # type: ignore
+#         hertz[torch.isnan(hertz)] = 0
+#         return hertz
 
-    def hertz_to_cents(self, hertz: torch.Tensor) -> torch.Tensor:
-        """Convert frequencies in hertz to cents"""
-        cents = 1200 * torch.log2(hertz / self.cents_reference_frequency_hz)
-        return cents
+#     def hertz_to_cents(self, hertz: torch.Tensor) -> torch.Tensor:
+#         """Convert frequencies in hertz to cents"""
+#         cents = 1200 * torch.log2(hertz / self.cents_reference_frequency_hz)
+#         return cents
 
-    def cents_to_bins(self, cents: torch.Tensor) -> torch.Tensor:
-        """Map frequencies in cents onto the self.num_bins_cents bins
+#     def cents_to_bins(self, cents: torch.Tensor) -> torch.Tensor:
+#         """Map frequencies in cents onto the self.num_bins_cents bins
 
-        Performs unnormalized local Gaussian bluring of the bins
+#         Performs unnormalized local Gaussian bluring of the bins
 
-        Input argument:
-            cents, torch.Tensor
+#         Input argument:
+#             cents, torch.Tensor
 
-        Return:
-            torch.Tensor with an added dimension of size
-                `self.num_bins_cents`
-        """
-        bins_center_distance = (
-            self._to_local_average_cents_matrix - cents.unsqueeze(-1))
-        # unnormalized gaussian as described in the original CREPE paper
-        return torch.exp((- bins_center_distance ** 2) /
-                         (2 * self.cents_gaussian_bluring_std_cents ** 2))
+#         Return:
+#             torch.Tensor with an added dimension of size
+#                 `self.num_bins_cents`
+#         """
+#         bins_center_distance = self._to_local_average_cents_matrix - cents.unsqueeze(-1)
+#         # unnormalized gaussian as described in the original CREPE paper
+#         return torch.exp(
+#             (-(bins_center_distance ** 2))
+#             / (2 * self.cents_gaussian_bluring_std_cents ** 2)
+#         )
 
-    def get_timestamps_tensor(self,  batch_size: int, duration_n: int,
-                              ) -> torch.Tensor:
-        return ((torch.arange(duration_n) * self.hop_length_s)
-                .unsqueeze(0)
-                .expand(batch_size, -1))
+#     def get_timestamps_tensor(
+#         self,
+#         batch_size: int,
+#         duration_n: int,
+#     ) -> torch.Tensor:
+#         return (
+#             (torch.arange(duration_n) * self.hop_length_s)
+#             .unsqueeze(0)
+#             .expand(batch_size, -1)
+#         )
 
-    def get_timestamps_tensor_like(self, input: torch.Tensor,
-                                   ) -> torch.Tensor:
-        return self.get_timestamps_tensor(*input.shape[:2])
+#     def get_timestamps_tensor_like(
+#         self,
+#         input: torch.Tensor,
+#     ) -> torch.Tensor:
+#         return self.get_timestamps_tensor(*input.shape[:2])
 
-    def interpret_activation(self, logits: torch.Tensor
-                             ) -> Tuple[torch.Tensor, torch.Tensor,
-                                        torch.Tensor]:
-        confidence = logits.max(dim=-1)[0]
+#     def interpret_activation(
+#         self, logits: torch.Tensor
+#     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+#         confidence = logits.max(dim=-1)[0]
 
-        cents = self.to_local_average_cents(logits)
-        frequency = self.cents_to_hz(cents)
+#         cents = self.to_local_average_cents(logits)
+#         frequency = self.cents_to_hz(cents)
 
-        time = self.get_timestamps_tensor_like(logits)
-        return time, frequency, confidence
+#         time = self.get_timestamps_tensor_like(logits)
+#         return time, frequency, confidence
 
-    def num_frames_in_samples(self, samples: torch.Tensor) -> int:
-        if self.center:
-            samples = F.pad(
-                samples,
-                [self.frame_duration_n//2, self.frame_duration_n//2],
-                mode='constant', value=0)
-        batch_size, duration_n = samples.shape[:2]
-        return batch_size * (1 + int((duration_n - self.frame_duration_n)
-                                     / self.hop_length_n))
+#     def num_frames_in_samples(self, samples: torch.Tensor) -> int:
+#         if self.center:
+#             samples = F.pad(
+#                 samples,
+#                 [self.frame_duration_n // 2, self.frame_duration_n // 2],
+#                 mode="constant",
+#                 value=0,
+#             )
+#         batch_size, duration_n = samples.shape[:2]
+#         return batch_size * (
+#             1 + int((duration_n - self.frame_duration_n) / self.hop_length_n)
+#         )
 
-    def get_frames(self, audio: torch.Tensor) -> torch.Tensor:
-        """Split the provided batch of audio samples into frames
+#     def prepare_audio(self, audio: torch.Tensor) -> torch.Tensor:
+#         if len(audio.shape) == 3:
+#             audio = audio.mean(-1)  # make mono
+#         audio = audio.float()
 
-        Parameters
-        ----------
-        audio : np.ndarray [shape=(B, N,) or (B, N, C)]
-            The audio samples. Multichannel audio will be downmixed.
-        sr : int
-            Sample rate of the audio samples. The audio will be resampled if
-            the sample rate is not 16 kHz, which is expected by the model.
-        center : boolean
-            - If `True` (default), the signal `audio` is padded so that frame
-            `D[:, t]` is centered at `audio[t * hop_length]`.
-            - If `False`, then `D[:, t]` begins at `audio[t * hop_length]`
-        step_size : int
-            The step size in seconds for running pitch estimation.
+#         if self.center:
+#             audio = F.pad(
+#                 audio,
+#                 [self.frame_duration_n // 2, self.frame_duration_n // 2],
+#                 mode="constant",
+#                 value=0,
+#             )
 
-        Returns
-        -------
-        frames : np.ndarray [shape=(B, T, 1024)]
-        """
-        if len(audio.shape) == 3:
-            audio = audio.mean(-1)  # make mono
-        audio = audio.float()
+#         return audio
 
-        if self.center:
-            audio = F.pad(
-                audio,
-                [self.frame_duration_n//2, self.frame_duration_n//2],
-                mode='constant', value=0)
+#     def get_frames(self, audio: torch.Tensor) -> torch.Tensor:
+#         """Split the provided batch of audio samples into frames
 
-        # must clone to remove shared memory after unfolding with overlap
-        # otherwise the normalization goes wrong
-        frames = audio.unfold(-1, self.frame_duration_n, self.hop_length_n
-                              ).clone()
+#         Parameters
+#         ----------
+#         audio : np.ndarray [shape=(B, N,) or (B, N, C)]
+#             The audio samples. Multichannel audio will be downmixed.
+#         sr : int
+#             Sample rate of the audio samples. The audio will be resampled if
+#             the sample rate is not 16 kHz, which is expected by the model.
+#         center : boolean
+#             - If `True` (default), the signal `audio` is padded so that frame
+#             `D[:, t]` is centered at `audio[t * hop_length]`.
+#             - If `False`, then `D[:, t]` begins at `audio[t * hop_length]`
+#         step_size : int
+#             The step size in seconds for running pitch estimation.
 
-        # normalize each frame -- this is expected by the model
-        if self.normalize:
-            frames = frames - frames.mean(dim=-1, keepdim=True)
-            frames = frames / (frames.std(dim=-1, keepdim=True) + 1e-6)
-        return frames
+#         Returns
+#         -------
+#         frames : np.ndarray [shape=(B, T, 1024)]
+#         """
+#         # if len(audio.shape) == 3:
+#         #     audio = audio.mean(-1)  # make mono
+#         # audio = audio.float()
 
-    def midi_to_hz(self, midi_pitches: torch.IntTensor) -> torch.Tensor:
-        return self.a4_frequency_hz * (  # type: ignore
-            2.0 ** ((midi_pitches - 69.0)/12.0))  # type: ignore
+#         # if self.center:
+#         #     audio = F.pad(
+#         #         audio,
+#         #         [self.frame_duration_n//2, self.frame_duration_n//2],
+#         #         mode='constant', value=0)
 
-    def make_targets(self, samples: torch.Tensor, pitches_midi: torch.IntTensor
-                     ) -> torch.Tensor:
-        pitches_hz = self.midi_to_hz(pitches_midi)
-        pitches_cents = self.hertz_to_cents(pitches_hz)
-        pitches_cents_bins = self.cents_to_bins(pitches_cents)
+#         # must clone to remove shared memory after unfolding with overlap
+#         # otherwise the normalization goes wrong
+#         frames = audio.unfold(-1, self.frame_duration_n, self.hop_length_n).clone()
 
-        n_frames_in_sample = self.num_frames_in_samples(samples[0][None])
-        batch_size = samples.shape[0]
-        pitches_cents_bins_per_frame = (
-            pitches_cents_bins.unsqueeze(1).expand(
-                batch_size, n_frames_in_sample, -1)).clone()
-        return pitches_cents_bins_per_frame
+#         # normalize each frame -- this is expected by the model
+#         if self.normalize:
+#             # frames = frames - frames.mean(dim=-1, keepdim=True)
+#             # frames = frames / (frames.std(dim=-1, keepdim=True) + 1e-6)
+#             torch.sub(frames, frames.mean(dim=-1, keepdim=True), out=frames)
+#             torch.div(frames, (frames.std(dim=-1, keepdim=True) + 1e-6), out=frames)
+#         return frames
+
+#     def midi_to_hz(self, midi_pitches: torch.IntTensor) -> torch.Tensor:
+#         return self.a4_frequency_hz * (  # type: ignore
+#             2.0 ** ((midi_pitches - 69.0) / 12.0)
+#         )  # type: ignore
+
+#     def make_targets(
+#         self, samples: torch.Tensor, pitches_midi: torch.IntTensor
+#     ) -> torch.Tensor:
+#         pitches_hz = self.midi_to_hz(pitches_midi)
+#         pitches_cents = self.hertz_to_cents(pitches_hz)
+#         pitches_cents_bins = self.cents_to_bins(pitches_cents)
+
+#         n_frames_in_sample = self.num_frames_in_samples(samples[0][None])
+#         batch_size = samples.shape[0]
+#         pitches_cents_bins_per_frame = (
+#             pitches_cents_bins.unsqueeze(1).expand(batch_size, n_frames_in_sample, -1)
+#         ).clone()
+#         return pitches_cents_bins_per_frame
 
 
 def build_and_load_model(model_capacity: str):
@@ -470,16 +504,17 @@ def build_and_load_model(model_capacity: str):
         filename = "model-{}.h5".format(model_capacity)
         model.load_keras_weights(os.path.join(package_dir, filename))
 
-        device = 'cuda:0' if torch.cuda.is_available() else 'cpu'
+        device = "cuda" if torch.cuda.is_available() else "cpu"
         model = model.to(device)
-
+        model.eval()
         models[model_capacity] = model
 
     return models[model_capacity]
 
 
-if __name__ == '__main__':
-    import torch
-    device = 'cpu'
-    model = build_and_load_model('tiny')
-    model(torch.randn(size=(1, 1, 1024)).to('cuda'))
+# if __name__ == "__main__":
+#     import torch
+
+#     device = "cpu"
+#     model = build_and_load_model("tiny")
+#     model(torch.randn(size=(1, 1, 1024)).to("cuda"))

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -4,12 +4,12 @@ import numpy as np
 import crepe
 
 # this data contains a sine sweep
-file = os.path.join(os.path.dirname(__file__), 'sweep.wav')
-f0_file = os.path.join(os.path.dirname(__file__), 'sweep.f0.csv')
+file = os.path.join(os.path.dirname(__file__), "sweep.wav")
+f0_file = os.path.join(os.path.dirname(__file__), "sweep.f0.csv")
 
 
 def verify_f0():
-    result = np.loadtxt(f0_file, delimiter=',', skiprows=1)
+    result = np.loadtxt(f0_file, delimiter=",", skiprows=1)
 
     # it should be confident enough about the presence of pitch in every frame
     assert np.mean(result[:, 2] > 0.5) > 0.98
@@ -21,72 +21,42 @@ def verify_f0():
 
 
 def test_sweep():
-    crepe.clear_model_cache()
     crepe.process_file(file)
     verify_f0()
 
 
-# def test_sweep_cli():
-#     result = subprocess.run(["crepe", file])
-#     # print(result)
-#     # assert result == 0
-#     assert False
-
-#     verify_f0()
-
-
-def test_sweep_torch():
-    crepe.clear_model_cache()
-    crepe.process_file(file, backend='torch')
+def test_sweep_cli():
+    result = subprocess.run(["crepe", file])
+    assert result == 0
     verify_f0()
 
 
-# # Test for frames slicing
-# # normalizing disabled due to numerical discrepancies between numpy and PyTorch
-# def test_get_frames_torch(normalize=False):
-#     import torch
-#     from crepe.torch_backend import DataHelper
-
-#     try:
-#         from scipy.io import wavfile
-#         sr, audio = wavfile.read(file)
-#     except ValueError:
-#         import sys
-#         print("CREPE: Could not read %s" % file, file=sys.stderr)
-#         raise
-#     frames_tf = crepe.core.get_frames(audio, sr, normalize=normalize)
-
-#     audio_torch = torch.as_tensor(audio).unsqueeze(0)
-#     data_helper = DataHelper(frame_duration_n=1024, hop_length_s=10e-3,
-#                              center=True, normalize=normalize)
-#     assert sr == data_helper.fs_hz
-#     frames_torch = data_helper.get_frames(audio_torch)[0].numpy()
-
-#     assert np.allclose(frames_tf, frames_torch)
+def test_sweep_torch():
+    crepe.process_file(file, backend="torch")
+    verify_f0()
 
 
 # test consistency of results between PyTorch and TF
 # passes only if using very lax parameters for the np.allclose comparison,
 # not sure if it's due to floating point numerical imprecisions
 # or to an actual bug...
-def dont_test_activation_torch_tf():
+def test_activation_torch_tf():
     try:
         from scipy.io import wavfile
+
         sr, audio = wavfile.read(file)
     except ValueError:
         import sys
+
         print("CREPE: Could not read %s" % file, file=sys.stderr)
         raise
 
-    *_, confidence_tf, activation_tf = crepe.predict(
-        audio, sr, backend='tf')
+    *_, confidence_tf, activation_tf = crepe.predict(audio, sr, backend="tf")
 
-    *_, confidence_torch, activation_torch = crepe.predict(
-        audio, sr, backend='torch')
+    *_, confidence_torch, activation_torch = crepe.predict(audio, sr, backend="torch")
 
     from functools import partial
+
     relaxed_allclose = partial(np.allclose, rtol=1e-2, atol=1e-8)
-    assert relaxed_allclose(confidence_tf,
-                            confidence_torch[0].cpu().numpy())
-    assert relaxed_allclose(activation_tf,
-                            activation_torch[0].cpu().numpy())
+    assert relaxed_allclose(confidence_tf, confidence_torch[0].cpu().numpy())
+    assert relaxed_allclose(activation_tf, activation_torch[0].cpu().numpy())

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import numpy as np
 import crepe
 
@@ -20,49 +21,55 @@ def verify_f0():
 
 
 def test_sweep():
+    crepe.clear_model_cache()
     crepe.process_file(file)
     verify_f0()
 
 
-def test_sweep_cli():
-    assert os.system("crepe {}".format(file)) == 0
-    verify_f0()
+# def test_sweep_cli():
+#     result = subprocess.run(["crepe", file])
+#     # print(result)
+#     # assert result == 0
+#     assert False
+
+#     verify_f0()
 
 
 def test_sweep_torch():
+    crepe.clear_model_cache()
     crepe.process_file(file, backend='torch')
     verify_f0()
 
 
-# Test for frames slicing
-# normalizing disabled due to numerical discrepancies between numpy and PyTorch
-def test_get_frames_torch(normalize=False):
-    import torch
-    from crepe.torch_backend import DataHelper
+# # Test for frames slicing
+# # normalizing disabled due to numerical discrepancies between numpy and PyTorch
+# def test_get_frames_torch(normalize=False):
+#     import torch
+#     from crepe.torch_backend import DataHelper
 
-    try:
-        from scipy.io import wavfile
-        sr, audio = wavfile.read(file)
-    except ValueError:
-        import sys
-        print("CREPE: Could not read %s" % file, file=sys.stderr)
-        raise
-    frames_tf = crepe.core.get_frames(audio, sr, normalize=normalize)
+#     try:
+#         from scipy.io import wavfile
+#         sr, audio = wavfile.read(file)
+#     except ValueError:
+#         import sys
+#         print("CREPE: Could not read %s" % file, file=sys.stderr)
+#         raise
+#     frames_tf = crepe.core.get_frames(audio, sr, normalize=normalize)
 
-    audio_torch = torch.as_tensor(audio).unsqueeze(0)
-    data_helper = DataHelper(frame_duration_n=1024, hop_length_s=10e-3,
-                             center=True, normalize=normalize)
-    assert sr == data_helper.fs_hz
-    frames_torch = data_helper.get_frames(audio_torch)[0].numpy()
+#     audio_torch = torch.as_tensor(audio).unsqueeze(0)
+#     data_helper = DataHelper(frame_duration_n=1024, hop_length_s=10e-3,
+#                              center=True, normalize=normalize)
+#     assert sr == data_helper.fs_hz
+#     frames_torch = data_helper.get_frames(audio_torch)[0].numpy()
 
-    assert np.allclose(frames_tf, frames_torch)
+#     assert np.allclose(frames_tf, frames_torch)
 
 
 # test consistency of results between PyTorch and TF
 # passes only if using very lax parameters for the np.allclose comparison,
 # not sure if it's due to floating point numerical imprecisions
 # or to an actual bug...
-def test_activation_torch_tf():
+def dont_test_activation_torch_tf():
     try:
         from scipy.io import wavfile
         sr, audio = wavfile.read(file)

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -74,10 +74,6 @@ def test_activation_torch_tf():
     *_, confidence_tf, activation_tf = crepe.predict(
         audio, sr, backend='tf')
 
-    import torch
-    audio = torch.as_tensor(audio).unsqueeze(0)
-    device = 'cuda:0' if torch.cuda.is_available() else 'cpu'
-    audio = audio.to(device)
     *_, confidence_torch, activation_torch = crepe.predict(
         audio, sr, backend='torch')
 


### PR DESCRIPTION
`get_activation` expects the signal as a numpy array (according to the doc string), but in several places the numpy array is converted to a torch tensor before being passed to `get_activation` (i.e. `get_activation` implicitly expects a torch tensor when the backend is "torch"). This inconsistency leads to an error when calling the `crepe.predict` function with a numpy array (as per docstring). The following is a minimal working example to trigger the error:

```python
import numpy as np
import crepe

samplerate = 16000  # Hz
duration = 5  # seconds
N = int(samplerate * duration)
signal = np.zeros(N)
crepe.predict(signal, samplerate, backend="torch")
```


This PR solves the above problem by moving the conversion of the signal to a torch tensor inside the `get_activation` function, before the call to `CREPE.forward_audio`.
